### PR TITLE
[NEW]: run multiple gcloud commands

### DIFF
--- a/gcloud/src/main/java/dev/chux/gcp/crun/gcloud/rest/RunGCloudCommandController.java
+++ b/gcloud/src/main/java/dev/chux/gcp/crun/gcloud/rest/RunGCloudCommandController.java
@@ -1,5 +1,8 @@
 package dev.chux.gcp.crun.gcloud.rest;
 
+import java.io.OutputStreamWriter;
+
+import java.util.List;
 import java.util.UUID;
 
 import javax.servlet.ServletOutputStream;
@@ -14,6 +17,7 @@ import spark.Request;
 import spark.Response;
 
 import dev.chux.gcp.crun.model.GCloudCommand;
+import dev.chux.gcp.crun.model.GCloudCommands;
 import dev.chux.gcp.crun.gcloud.GCloudService;
 import dev.chux.gcp.crun.rest.Route;
 
@@ -21,7 +25,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static spark.Spark.*;
+
+import static com.google.common.base.Optional.absent;
+import static com.google.common.base.Optional.fromNullable;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.emptyToNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import static java.util.Collections.singletonList;
 
 public class RunGCloudCommandController implements Route {
   private static final Logger logger = LoggerFactory.getLogger(RunGCloudCommandController.class);
@@ -56,49 +69,120 @@ public class RunGCloudCommandController implements Route {
     final String executionID = UUID.randomUUID().toString();
 
     final String rawJSON = request.body();
-    final String namespace = request.params(":namespace");
-    final String output = request.queryParams("output"); 
-    
-    final ServletOutputStream responseOutput = response.raw().getOutputStream();
+    final String namespace = emptyToNull(request.params(":namespace"));
 
     response.header("x-gcloud-execution-id", executionID);
 
-    final Optional<GCloudCommand> maybeCmd = this.command(rawJSON);
-    if (!maybeCmd.isPresent()) {
-      halt(404, "command not found");
-      return null;
-    }
-
-    final GCloudCommand cmd = maybeCmd.get();
-
-    if (!isNullOrEmpty(namespace)) {
-      // namespace is optional to allow for commands like `gcloud --help`
-      response.header("x-gcloud-namespace", namespace);
-      cmd.namespace(namespace);
-    }
-
     logger.info("starting: {}", executionID);
 
-    if( isNullOrEmpty(output) ) {
-      this.gcloudService.run(cmd, responseOutput);
+    final Optional<GCloudCommands> commands;
+    if ( isNullOrEmpty(namespace) || !namespace.equalsIgnoreCase("all") ) {
+      commands = toGCloudCommands(
+        fromNullable(namespace), this.commandPayload(rawJSON)
+      );
     } else {
-      this.gcloudService.run(cmd);
+      commands = this.commandsPayload(rawJSON);
+    }
+
+    if ( commands.isPresent() ) {
+      this.runCommands(request, response, commands.get());
+    } else {
+      halt(404, "command(s) not found");
     }
     
     logger.info("finished: {}", executionID);
+
     return null;
   }
 
-  private final Optional<GCloudCommand> command(final String rawJSON) {
+  private final Optional<GCloudCommands> toGCloudCommands(
+    final Optional<String> namespace,
+    final Optional<GCloudCommand> command
+  ) {
+    if ( !command.isPresent() ) { return absent(); }
+    return Optional.of(
+      this.newGCloudCommands(singletonList(
+        this.setNamespace(namespace, command.get())
+      ))
+    );
+  }
+
+  private final GCloudCommand setNamespace(
+    final Optional<String> namespace,
+    final GCloudCommand command
+  ) {
+    checkNotNull(command);
+    if ( namespace.isPresent() ) {
+      command.namespace(namespace.get());
+    }
+    return command;
+  }
+
+  private final GCloudCommands newGCloudCommands(
+    final List<GCloudCommand> commands
+  ) {
+    return new GCloudCommands(commands);
+  }
+
+  private final void runCommand(
+    final Request request,
+    final Response response,
+    final GCloudCommand command
+  )  throws Exception {
+    checkNotNull(command);
+
+    logger.info("running GCloud Command: {}", command);
+
+    final String output = request.queryParams("output"); 
+
+    if( isNullOrEmpty(output) ) {
+      this.gcloudService.run(command, response.raw().getOutputStream());
+    } else {
+      this.gcloudService.run(command);
+    }
+  }
+
+  private final void runCommands(
+    final Request request,
+    final Response response,
+    final GCloudCommands commands
+  )  throws Exception {
+    checkNotNull(commands);
+
+    if ( commands.get().isEmpty() ) {
+      // see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+      halt(204, "no commands");
+      return;
+    }
+
+    final OutputStreamWriter writer =
+      new OutputStreamWriter(response.raw().getOutputStream(), UTF_8);
+
+    for (final GCloudCommand command : commands.get()) {
+      this.runCommand(request, response, command);
+      writer.write("\n---\n");
+      writer.flush();
+    }
+  }
+
+  private final Optional<GCloudCommand> commandPayload(final String rawJSON) {
+    return this.payload(rawJSON, GCloudCommand.class);
+  }
+
+  private final Optional<GCloudCommands> commandsPayload(final String rawJSON) {
+    return this.payload(rawJSON, GCloudCommands.class);
+  }
+
+  private final <T> Optional<T> payload(final String rawJSON, final Class<T> clazz) {
     try {
-      final GCloudCommand cmd = this.gson.fromJson(rawJSON, GCloudCommand.class);
-      return Optional.fromNullable(cmd);
+      final T cmd = this.gson.fromJson(rawJSON, clazz);
+      return Optional.<T>fromNullable(cmd);
     } catch(Exception ex) {
       ex.printStackTrace(System.err);
-      logger.error("invalid 'gcloud' command: {}", rawJSON);
+      logger.error("invalid 'gcloud' payload: {}", rawJSON);
       logger.error("failed to parse json", ex);
     }
-    return Optional.absent();
+    return Optional.<T>absent();
   }
 
 }

--- a/model/src/main/java/dev/chux/gcp/crun/model/GCloudCommand.java
+++ b/model/src/main/java/dev/chux/gcp/crun/model/GCloudCommand.java
@@ -12,13 +12,14 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.Since;
 import com.google.gson.annotations.SerializedName;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Optional.fromNullable;
 import static com.google.common.base.Strings.emptyToNull;
 
 public class GCloudCommand {
 
   @Since(1.0)
-  @Expose(deserialize=false, serialize=true)
+  @Expose(deserialize=true, serialize=true)
   @SerializedName(value="namespace", alternate={"ns"})
   private String namespace;
 
@@ -96,6 +97,18 @@ public class GCloudCommand {
       return ImmutableMap.of();
     } 
     return ImmutableMap.copyOf(this.flags);
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+      .add("namespace", this.optionalNamespace())
+      .add("groups", this.groups())
+      .add("flags", this.flags())
+      .add("format", this.optionalFormat())
+      .add("command", this.optionalCommand())
+      .add("arguments", this.arguments())
+      .toString();
   }
 
 }

--- a/model/src/main/java/dev/chux/gcp/crun/model/GCloudCommands.java
+++ b/model/src/main/java/dev/chux/gcp/crun/model/GCloudCommands.java
@@ -1,0 +1,48 @@
+package dev.chux.gcp.crun.model;
+
+import java.util.List;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.Since;
+import com.google.gson.annotations.SerializedName;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class GCloudCommands implements Supplier<List<GCloudCommand>> {
+
+  @Since(1.0)
+  @Expose(deserialize=true, serialize=true)
+  @SerializedName(value="commands", alternate={"cmds"})
+  private List<GCloudCommand> commands;
+
+  GCloudCommands() {}
+
+  public GCloudCommands(final List<GCloudCommand> commands) {
+    this.commands = checkNotNull(commands);
+  }
+  
+  public List<GCloudCommand> commands() {
+    if( this.commands == null ) {
+      return ImmutableList.of();
+    } 
+    return ImmutableList.copyOf(this.commands);
+  }
+
+  @Override
+  public List<GCloudCommand> get() {
+    return this.commands();
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+      .add("commands", this.commands())
+      .toString();
+  }
+
+}
+

--- a/model/src/main/java/dev/chux/gcp/crun/model/HttpProxy.java
+++ b/model/src/main/java/dev/chux/gcp/crun/model/HttpProxy.java
@@ -1,12 +1,12 @@
 package dev.chux.gcp.crun.model;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.Since;
 import com.google.gson.annotations.SerializedName;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Optional.fromNullable;
 import static com.google.common.base.Strings.emptyToNull;
 
@@ -47,8 +47,7 @@ public class HttpProxy {
 
   @Override
   public String toString() {
-    return MoreObjects
-      .toStringHelper(this)
+    return toStringHelper(this)
       .add("host", this.host())
       .add("port", this.port())
       .add("secure", this.optionalIsSecure())

--- a/model/src/main/java/dev/chux/gcp/crun/model/HttpRequest.java
+++ b/model/src/main/java/dev/chux/gcp/crun/model/HttpRequest.java
@@ -2,7 +2,6 @@ package dev.chux.gcp.crun.model;
 
 import java.util.Map;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 
 import com.google.common.collect.ImmutableMap;
@@ -11,6 +10,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.Since;
 import com.google.gson.annotations.SerializedName;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Optional.fromNullable;
 import static com.google.common.base.Strings.emptyToNull;
 
@@ -80,7 +80,7 @@ public class HttpRequest {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
+    return toStringHelper(this)
       .add("url", this.url())
       .add("method", this.optionalMethod())
       .add("headers", this.headers())


### PR DESCRIPTION
@thomasmburke 

adding support to run multiple gcloud commands based on:

- https://github.com/gchux/jmeter-test-runner/blob/feature/gcloud/model/src/main/java/dev/chux/gcp/crun/model/GCloudCommands.java

path: `/gcloud/exec/all`

sample payload:

```json
{
  "commands": [
    {
      "namespace": "run",
      "flags": {
        "help": ""
      }
    },
    {
      "namespace": "app",
      "flags": {
        "help": ""
      }
    }
  ]
}
```